### PR TITLE
Centralize kernel template numeric coercion

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -1,6 +1,7 @@
 import itertools as it
 import re
 import types
+import numpy as np
 
 from pyfr.cache import memoize
 
@@ -67,6 +68,11 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
     def _render_kernel(self, name, mod, extrns, tplargs):
         # Copy the provided argument list
         tplargs = dict(tplargs)
+
+        # Convert numeric template arguments to full-precision strings
+        for k, v in list(tplargs.items()):
+            if isinstance(v, (int, float, np.floating)):
+                tplargs[k] = f"{float(v):.17g}"
 
         # Backend-specfic generator classes
         tplargs['_kernel_generator'] = self.kernel_generator_cls

--- a/pyfr/tests/test_render_kernel.py
+++ b/pyfr/tests/test_render_kernel.py
@@ -1,0 +1,48 @@
+import importlib.machinery as imm
+import importlib.util as imu
+from pathlib import Path
+
+import numpy as np
+from mako.template import Template
+
+# Import BasePointwiseKernelProvider without triggering backend initialisation
+kernel_path = Path(__file__).resolve().parents[1] / 'backends' / 'base' / 'kernels.py'
+loader = imm.SourceFileLoader('kernels', str(kernel_path))
+spec = imu.spec_from_loader(loader.name, loader)
+kernels = imu.module_from_spec(spec)
+loader.exec_module(kernels)
+BasePointwiseKernelProvider = kernels.BasePointwiseKernelProvider
+
+
+class DummyLookup:
+    def __init__(self, src):
+        self.src = src
+
+    def get_template(self, mod):
+        return Template(self.src)
+
+
+class DummyBackend:
+    def __init__(self, src):
+        self.lookup = DummyLookup(src)
+
+
+class DummyProvider(BasePointwiseKernelProvider):
+    kernel_generator_cls = object
+
+
+def test_render_kernel_numeric_coercion():
+    tplsrc = '''
+<%
+_kernel_argspecs['foo'] = (0, [], [])
+%>
+${x} ${y}
+'''
+    backend = DummyBackend(tplsrc)
+    provider = DummyProvider(backend)
+
+    tplargs = {'x': 1/3, 'y': np.float64(1/7)}
+    src, ndim, argn, argt = provider._render_kernel('foo', 'foo', {}, tplargs)
+
+    assert '0.33333333333333331' in src
+    assert '0.14285714285714285' in src


### PR DESCRIPTION
## Summary
- format integer and floating template arguments to full-precision strings before Mako rendering
- add regression test ensuring `_render_kernel` preserves numeric precision

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689af15d0568832f8bcf66fe1d546201