### PR TITLE
Expose float formatting helper

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -6,6 +6,10 @@ import numpy as np
 from pyfr.cache import memoize
 
 
+def fmt_float(f):
+    return f"{float(f):.17g}"
+
+
 class Kernel:
     compound = False
 
@@ -83,6 +87,7 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
                 return v
 
         tplargs = {k: coerce(v) for k, v in dict(tplargs).items()}
+        tplargs['fmt'] = fmt_float
 
         # Backend-specfic generator classes
         tplargs['_kernel_generator'] = self.kernel_generator_cls


### PR DESCRIPTION
## Summary
- Hoist `fmt_float` helper so templates can format floats consistently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b3df76a50832f8245bfa32d056e40