### PR TITLE
Verify float fmt in kernel rendering tests

### DIFF
--- a/pyfr/tests/test_kernel_numeric_args.py
+++ b/pyfr/tests/test_kernel_numeric_args.py
@@ -36,17 +36,18 @@ def test_float_coercion():
     tplsrc = """
 <%
 _kernel_argspecs['foo'] = (0, [], [])
+name = 'coef_' + fmt(x)
 %>
-${x}
+${name}
 """
 
     backend = DummyBackend(tplsrc)
     provider = DummyProvider(backend)
 
-    tplargs = {'x': np.float64(1/3)}
+    tplargs = {'x': np.float64(1 / 3)}
     src, ndim, argn, argt = provider._render_kernel('foo', 'foo', {}, tplargs)
 
-    assert '0.33333333333333331' in src
+    assert 'coef_0.33333333333333331' in src
 
 
 def test_integer_range_loop():

--- a/pyfr/tests/test_render_kernel.py
+++ b/pyfr/tests/test_render_kernel.py
@@ -36,13 +36,13 @@ def test_render_kernel_numeric_coercion():
 <%
 _kernel_argspecs['foo'] = (0, [], [])
 %>
-${x} ${y}
+${x} ${fmt(x)}
 '''
     backend = DummyBackend(tplsrc)
     provider = DummyProvider(backend)
 
-    tplargs = {'x': 1/3, 'y': np.float64(1/7)}
+    tplargs = {'x': 1 / 3}
     src, ndim, argn, argt = provider._render_kernel('foo', 'foo', {}, tplargs)
 
+    assert '0.3333333333333333' in src
     assert '0.33333333333333331' in src
-    assert '0.14285714285714285' in src


### PR DESCRIPTION
## Summary
- Test float-to-text coercion via `fmt` in kernel numeric args
- Cover both numeric and `fmt` rendering paths for template floats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3f0a604c832fbef826795f84eac4