### PR TITLE
test: check numeric param multiplication

### DIFF
--- a/pyfr/tests/test_kernel_numeric_args.py
+++ b/pyfr/tests/test_kernel_numeric_args.py
@@ -68,3 +68,20 @@ ${i}
 
     assert '0\n1\n2\n3' in src
 
+
+def test_numeric_param_multiplication():
+    tplsrc = """
+<%
+_kernel_argspecs['foo'] = (0, [], [])
+%>
+${fmt(a*b)}
+"""
+
+    backend = DummyBackend(tplsrc)
+    provider = DummyProvider(backend)
+
+    tplargs = {'a': np.int32(2), 'b': np.float64(1 / 3)}
+    src, ndim, argn, argt = provider._render_kernel('foo', 'foo', {}, tplargs)
+
+    assert '0.66666666666666663' in src
+


### PR DESCRIPTION
## Summary
- test kernel numeric args multiply as numbers and embed float literal via fmt

## Testing
- `pytest pyfr/tests/test_kernel_numeric_args.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b61c9a960832f93ca95b8aa728b71