### PR TITLE
Enforce numeric kernel tplargs

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -73,6 +73,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
                 return int(v)
             elif isinstance(v, (float, np.floating)):
                 return float(v)
+            elif isinstance(v, (str, bytes, np.str_, np.bytes_)):
+                raise TypeError('Kernel argument values must be numeric')
             elif isinstance(v, list):
                 return [coerce(i) for i in v]
             elif isinstance(v, tuple):

--- a/pyfr/tests/test_kernel_numeric_args.py
+++ b/pyfr/tests/test_kernel_numeric_args.py
@@ -3,6 +3,7 @@ import importlib.util as imu
 from pathlib import Path
 
 import numpy as np
+import pytest
 from mako.template import Template
 
 
@@ -84,4 +85,34 @@ ${a*b}
     src, ndim, argn, argt = provider._render_kernel('foo', 'foo', {}, tplargs)
 
     assert '0.6666666666666666' in src
+
+
+def test_string_tplarg_rejected():
+    tplsrc = """
+<%
+_kernel_argspecs['foo'] = (0, [], [])
+%>
+${x}
+"""
+
+    backend = DummyBackend(tplsrc)
+    provider = DummyProvider(backend)
+
+    with pytest.raises(TypeError):
+        provider._render_kernel('foo', 'foo', {}, {'x': '1'})
+
+
+def test_bytes_tplarg_rejected():
+    tplsrc = """
+<%
+_kernel_argspecs['foo'] = (0, [], [])
+%>
+${x}
+"""
+
+    backend = DummyBackend(tplsrc)
+    provider = DummyProvider(backend)
+
+    with pytest.raises(TypeError):
+        provider._render_kernel('foo', 'foo', {}, {'x': b'1'})
 


### PR DESCRIPTION
## Summary
- reject string and bytes values in kernel template arguments
- cover tplarg validation with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b6435eb88832fa2ede3d8af98c016