### PR TITLE
Use fmt for kernel template dimensions

### DIFF
--- a/pyfr/integrators/std/kernels/rkvdh2.mako
+++ b/pyfr/integrators/std/kernels/rkvdh2.mako
@@ -2,10 +2,10 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 <%pyfr:kernel name='rkvdh2' ndim='2'
-              r1='inout fpdtype_t[${str(nvars)}]'
-              r2='inout fpdtype_t[${str(nvars)}]'
-              rold='out fpdtype_t[${str(nvars)}]'
-              rerr='inout fpdtype_t[${str(nvars)}]'
+              r1='inout fpdtype_t[${fmt(nvars)}]'
+              r2='inout fpdtype_t[${fmt(nvars)}]'
+              rold='out fpdtype_t[${fmt(nvars)}]'
+              rerr='inout fpdtype_t[${fmt(nvars)}]'
               dt='scalar fpdtype_t'>
     fpdtype_t tmpr1[] = ${pyfr.array('r1[{j}]', j=nvars)};
     fpdtype_t tmpr2[] = ${pyfr.array('r2[{j}]', j=nvars)};

--- a/pyfr/solvers/aceuler/kernels/bccflux.mako
+++ b/pyfr/solvers/aceuler/kernels/bccflux.mako
@@ -5,8 +5,8 @@
 <%include file='pyfr.solvers.aceuler.kernels.bcs.${bctype}'/>
 
 <%pyfr:kernel name='bccflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/aceuler/kernels/intcflux.mako
+++ b/pyfr/solvers/aceuler/kernels/intcflux.mako
@@ -4,9 +4,9 @@
 <%include file='pyfr.solvers.aceuler.kernels.rsolvers.${rsolver}'/>
 
 <%pyfr:kernel name='intcflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='inout view fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='inout view fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/aceuler/kernels/mpicflux.mako
+++ b/pyfr/solvers/aceuler/kernels/mpicflux.mako
@@ -4,9 +4,9 @@
 <%include file='pyfr.solvers.aceuler.kernels.rsolvers.${rsolver}'/>
 
 <%pyfr:kernel name='mpicflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='in mpi fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='in mpi fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/aceuler/kernels/tflux.mako
+++ b/pyfr/solvers/aceuler/kernels/tflux.mako
@@ -6,11 +6,11 @@
 <% smats = 'smats_l' if 'linear' in ktype else 'smats' %>
 
 <%pyfr:kernel name='tflux' ndim='2'
-              u='in fpdtype_t[${str(nvars)}]'
-              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
-              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
-              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+              u='in fpdtype_t[${fmt(nvars)}]'
+              f='out fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              smats='in fpdtype_t[${fmt(ndims)}][${fmt(ndims)}]'
+              verts='in broadcast-col fpdtype_t[${fmt(nverts)}][${fmt(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${fmt(ndims)}]'>
 % if 'linear' in ktype:
     // Compute the S matrices
     fpdtype_t ${smats}[${ndims}][${ndims}], djac;

--- a/pyfr/solvers/acnavstokes/kernels/bccflux.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bccflux.mako
@@ -8,9 +8,9 @@
 % endif
 
 <%pyfr:kernel name='bccflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              gradul='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/acnavstokes/kernels/bcconu.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcconu.mako
@@ -4,9 +4,9 @@
 <%include file='pyfr.solvers.acnavstokes.kernels.bcs.${bctype}'/>
 
 <%pyfr:kernel name='bcconu' ndim='1'
-              ulin='in view fpdtype_t[${str(nvars)}]'
-              ulout='out view fpdtype_t[${str(nvars)}]'
-              nlin='in fpdtype_t[${str(ndims)}]'>
+              ulin='in view fpdtype_t[${fmt(nvars)}]'
+              ulout='out view fpdtype_t[${fmt(nvars)}]'
+              nlin='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nlin[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nlin[{i}]', i=ndims)};
 

--- a/pyfr/solvers/acnavstokes/kernels/intcflux.mako
+++ b/pyfr/solvers/acnavstokes/kernels/intcflux.mako
@@ -7,11 +7,11 @@
 <% beta, tau = c['ldg-beta'], c['ldg-tau'] %>
 
 <%pyfr:kernel name='intcflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='inout view fpdtype_t[${str(nvars)}]'
-              gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              gradur='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='inout view fpdtype_t[${fmt(nvars)}]'
+              gradul='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              gradur='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/acnavstokes/kernels/intconu.mako
+++ b/pyfr/solvers/acnavstokes/kernels/intconu.mako
@@ -2,10 +2,10 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 <%pyfr:kernel name='intconu' ndim='1'
-              ulin='in view fpdtype_t[${str(nvars)}]'
-              urin='in view fpdtype_t[${str(nvars)}]'
-              ulout='out view fpdtype_t[${str(nvars)}]'
-              urout='out view fpdtype_t[${str(nvars)}]'>
+              ulin='in view fpdtype_t[${fmt(nvars)}]'
+              urin='in view fpdtype_t[${fmt(nvars)}]'
+              ulout='out view fpdtype_t[${fmt(nvars)}]'
+              urout='out view fpdtype_t[${fmt(nvars)}]'>
 % for i in range(nvars):
 % if c['ldg-beta'] == -0.5:
     urout[${i}] = ulin[${i}];

--- a/pyfr/solvers/acnavstokes/kernels/mpicflux.mako
+++ b/pyfr/solvers/acnavstokes/kernels/mpicflux.mako
@@ -7,11 +7,11 @@
 <% beta, tau = c['ldg-beta'], c['ldg-tau'] %>
 
 <%pyfr:kernel name='mpicflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='inout mpi fpdtype_t[${str(nvars)}]'
-              gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              gradur='in mpi fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='inout mpi fpdtype_t[${fmt(nvars)}]'
+              gradul='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              gradur='in mpi fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/acnavstokes/kernels/mpiconu.mako
+++ b/pyfr/solvers/acnavstokes/kernels/mpiconu.mako
@@ -2,9 +2,9 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 <%pyfr:kernel name='mpiconu' ndim='1'
-              ulin='in view fpdtype_t[${str(nvars)}]'
-              urin='in mpi fpdtype_t[${str(nvars)}]'
-              ulout='out view fpdtype_t[${str(nvars)}]'>
+              ulin='in view fpdtype_t[${fmt(nvars)}]'
+              urin='in mpi fpdtype_t[${fmt(nvars)}]'
+              ulout='out view fpdtype_t[${fmt(nvars)}]'>
 % for i in range(nvars):
 % if c['ldg-beta'] == -0.5:
     ulout[${i}] = ulin[${i}];

--- a/pyfr/solvers/acnavstokes/kernels/tflux.mako
+++ b/pyfr/solvers/acnavstokes/kernels/tflux.mako
@@ -12,13 +12,13 @@
 <% rcpdjac = 'rcpdjac_l' if 'linear' in ktype else 'rcpdjac' %>
 
 <%pyfr:kernel name='tflux' ndim='2'
-              u='in fpdtype_t[${str(nvars)}]'
-              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              gradu='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
+              u='in fpdtype_t[${fmt(nvars)}]'
+              f='inout fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              gradu='inout fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              smats='in fpdtype_t[${fmt(ndims)}][${fmt(ndims)}]'
               rcpdjac='in fpdtype_t'
-              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
-              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+              verts='in broadcast-col fpdtype_t[${fmt(nverts)}][${fmt(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${fmt(ndims)}]'>
 % if 'linear' in ktype:
     // Compute the S matrices
     fpdtype_t ${smats}[${ndims}][${ndims}], djac;

--- a/pyfr/solvers/baseadvec/kernels/evalsrcmacros.mako
+++ b/pyfr/solvers/baseadvec/kernels/evalsrcmacros.mako
@@ -6,8 +6,8 @@
 
 <%pyfr:kernel name='evalsrcmacros' ndim='2'
               t='scalar fpdtype_t'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              u='inout fpdtype_t[${str(nvars)}]'>
+              ploc='in fpdtype_t[${fmt(ndims)}]'
+              u='inout fpdtype_t[${fmt(nvars)}]'>
 fpdtype_t src[${nvars}] = {};
 
 % for mod, name in src_macros:

--- a/pyfr/solvers/baseadvec/kernels/negdivconf.mako
+++ b/pyfr/solvers/baseadvec/kernels/negdivconf.mako
@@ -6,9 +6,9 @@
 
 <%pyfr:kernel name='negdivconf' ndim='2'
               t='scalar fpdtype_t'
-              tdivtconf='inout fpdtype_t[${str(nvars)}]'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              u='in fpdtype_t[${str(nvars)}]'
+              tdivtconf='inout fpdtype_t[${fmt(nvars)}]'
+              ploc='in fpdtype_t[${fmt(ndims)}]'
+              u='in fpdtype_t[${fmt(nvars)}]'
               rcpdjac='in fpdtype_t'>
 fpdtype_t src[${nvars}] = {};
 

--- a/pyfr/solvers/baseadvecdiff/kernels/gradcoru.mako
+++ b/pyfr/solvers/baseadvecdiff/kernels/gradcoru.mako
@@ -8,11 +8,11 @@
 <% rcpdjac = 'rcpdjac_l' if 'linear' in ktype else 'rcpdjac' %>
 
 <%pyfr:kernel name='gradcoru' ndim='2'
-              gradu='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
+              gradu='inout fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              smats='in fpdtype_t[${fmt(ndims)}][${fmt(ndims)}]'
               rcpdjac='in fpdtype_t'
-              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
-              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+              verts='in broadcast-col fpdtype_t[${fmt(nverts)}][${fmt(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${fmt(ndims)}]'>
 % if 'linear' in ktype:
     // Compute the S matrices
     fpdtype_t ${smats}[${ndims}][${ndims}], djac;

--- a/pyfr/solvers/baseadvecdiff/kernels/shocksensor.mako
+++ b/pyfr/solvers/baseadvecdiff/kernels/shocksensor.mako
@@ -4,7 +4,7 @@
 <% se0 = math.log10(c['s0']/order**4) %>
 
 <%pyfr:kernel name='shocksensor' ndim='1'
-              u='in fpdtype_t[${str(nupts)}][${str(nvars)}]'
+              u='in fpdtype_t[${fmt(nupts)}][${fmt(nvars)}]'
               artvisc='out fpdtype_t'>
     // Smoothness indicator
     fpdtype_t totEn = 0.0, pnEn = 1e-15, tmp;

--- a/pyfr/solvers/euler/kernels/bccent.mako
+++ b/pyfr/solvers/euler/kernels/bccent.mako
@@ -5,8 +5,8 @@
 <%include file='pyfr.solvers.euler.kernels.entropy'/>
 
 <%pyfr:kernel name='bccent' ndim='1'
-              ul='in view fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'
+              ul='in view fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'
               entmin_lhs='out view reduce(min) fpdtype_t'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};

--- a/pyfr/solvers/euler/kernels/bccflux.mako
+++ b/pyfr/solvers/euler/kernels/bccflux.mako
@@ -5,8 +5,8 @@
 <%include file='pyfr.solvers.euler.kernels.bcs.${bctype}'/>
 
 <%pyfr:kernel name='bccflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/euler/kernels/entropyfilter.mako
+++ b/pyfr/solvers/euler/kernels/entropyfilter.mako
@@ -85,11 +85,11 @@
 </%pyfr:macro>
 
 <%pyfr:kernel name='entropyfilter' ndim='1'
-              u='inout fpdtype_t[${str(nupts)}][${str(nvars)}]'
-              entmin_int='inout fpdtype_t[${str(nfaces)}]'
-              vdm='in broadcast fpdtype_t[${str(nefpts)}][${str(nupts)}]'
-              invvdm='in broadcast fpdtype_t[${str(nupts)}][${str(nupts)}]'
-              m0='in broadcast fpdtype_t[${str(nfpts)}][${str(nupts)}]'>
+              u='inout fpdtype_t[${fmt(nupts)}][${fmt(nvars)}]'
+              entmin_int='inout fpdtype_t[${fmt(nfaces)}]'
+              vdm='in broadcast fpdtype_t[${fmt(nefpts)}][${fmt(nupts)}]'
+              invvdm='in broadcast fpdtype_t[${fmt(nupts)}][${fmt(nupts)}]'
+              m0='in broadcast fpdtype_t[${fmt(nfpts)}][${fmt(nupts)}]'>
     fpdtype_t dmin, pmin, emin;
     fpdtype_t Rgas = ${c['R']}, ag = ${c['a']}, bg = ${c['b']}, cvg = ${c['cv']};
 

--- a/pyfr/solvers/euler/kernels/entropylocal.mako
+++ b/pyfr/solvers/euler/kernels/entropylocal.mako
@@ -3,9 +3,9 @@
 <%include file='pyfr.solvers.euler.kernels.entropy'/>
 
 <%pyfr:kernel name='entropylocal' ndim='1'
-              u='in fpdtype_t[${str(nupts)}][${str(nvars)}]'
-              entmin_int='out fpdtype_t[${str(nfaces)}]'
-              m0='in broadcast fpdtype_t[${str(nfpts)}][${str(nupts)}]'>
+              u='in fpdtype_t[${fmt(nupts)}][${fmt(nvars)}]'
+              entmin_int='out fpdtype_t[${fmt(nfaces)}]'
+              m0='in broadcast fpdtype_t[${fmt(nfpts)}][${fmt(nupts)}]'>
     fpdtype_t Rgas = ${c['R']}, ag = ${c['a']}, bg = ${c['b']}, cvg = ${c['cv']};
 
     // Compute minimum entropy across element

--- a/pyfr/solvers/euler/kernels/intcflux.mako
+++ b/pyfr/solvers/euler/kernels/intcflux.mako
@@ -4,9 +4,9 @@
 <%include file='pyfr.solvers.euler.kernels.rsolvers.${rsolver}'/>
 
 <%pyfr:kernel name='intcflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='inout view fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='inout view fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/euler/kernels/mpicflux.mako
+++ b/pyfr/solvers/euler/kernels/mpicflux.mako
@@ -4,9 +4,9 @@
 <%include file='pyfr.solvers.euler.kernels.rsolvers.${rsolver}'/>
 
 <%pyfr:kernel name='mpicflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='in mpi fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='in mpi fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/euler/kernels/tflux.mako
+++ b/pyfr/solvers/euler/kernels/tflux.mako
@@ -6,11 +6,11 @@
 <% smats = 'smats_l' if 'linear' in ktype else 'smats' %>
 
 <%pyfr:kernel name='tflux' ndim='2'
-              u='in fpdtype_t[${str(nvars)}]'
-              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
-              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
-              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+              u='in fpdtype_t[${fmt(nvars)}]'
+              f='out fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              smats='in fpdtype_t[${fmt(ndims)}][${fmt(ndims)}]'
+              verts='in broadcast-col fpdtype_t[${fmt(nverts)}][${fmt(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${fmt(ndims)}]'>
 % if 'linear' in ktype:
     // Compute the S matrices
     fpdtype_t ${smats}[${ndims}][${ndims}], djac;

--- a/pyfr/solvers/navstokes/kernels/bccent.mako
+++ b/pyfr/solvers/navstokes/kernels/bccent.mako
@@ -5,8 +5,8 @@
 <%include file='pyfr.solvers.euler.kernels.entropy'/>
 
 <%pyfr:kernel name='bccent' ndim='1'
-              ul='in view fpdtype_t[${str(nvars)}]'
-              nl='in fpdtype_t[${str(ndims)}]'
+              ul='in view fpdtype_t[${fmt(nvars)}]'
+              nl='in fpdtype_t[${fmt(ndims)}]'
               entmin_lhs='out view reduce(min) fpdtype_t'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};

--- a/pyfr/solvers/navstokes/kernels/bccflux.mako
+++ b/pyfr/solvers/navstokes/kernels/bccflux.mako
@@ -8,10 +8,10 @@
 % endif
 
 <%pyfr:kernel name='bccflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              gradul='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
               artviscl='in view fpdtype_t'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/navstokes/kernels/bcconu.mako
+++ b/pyfr/solvers/navstokes/kernels/bcconu.mako
@@ -4,9 +4,9 @@
 <%include file='pyfr.solvers.navstokes.kernels.bcs.${bctype}'/>
 
 <%pyfr:kernel name='bcconu' ndim='1'
-              ulin='in view fpdtype_t[${str(nvars)}]'
-              ulout='out view fpdtype_t[${str(nvars)}]'
-              nlin='in fpdtype_t[${str(ndims)}]'>
+              ulin='in view fpdtype_t[${fmt(nvars)}]'
+              ulout='out view fpdtype_t[${fmt(nvars)}]'
+              nlin='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nlin[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nlin[{i}]', i=ndims)};
 

--- a/pyfr/solvers/navstokes/kernels/intcflux.mako
+++ b/pyfr/solvers/navstokes/kernels/intcflux.mako
@@ -8,13 +8,13 @@
 <% beta, tau = c['ldg-beta'], c['ldg-tau'] %>
 
 <%pyfr:kernel name='intcflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='inout view fpdtype_t[${str(nvars)}]'
-              gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              gradur='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='inout view fpdtype_t[${fmt(nvars)}]'
+              gradul='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              gradur='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
               artviscl='in view fpdtype_t'
               artviscr='in view fpdtype_t'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/navstokes/kernels/intconu.mako
+++ b/pyfr/solvers/navstokes/kernels/intconu.mako
@@ -2,10 +2,10 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 <%pyfr:kernel name='intconu' ndim='1'
-              ulin='in view fpdtype_t[${str(nvars)}]'
-              urin='in view fpdtype_t[${str(nvars)}]'
-              ulout='out view fpdtype_t[${str(nvars)}]'
-              urout='out view fpdtype_t[${str(nvars)}]'>
+              ulin='in view fpdtype_t[${fmt(nvars)}]'
+              urin='in view fpdtype_t[${fmt(nvars)}]'
+              ulout='out view fpdtype_t[${fmt(nvars)}]'
+              urout='out view fpdtype_t[${fmt(nvars)}]'>
 % for i in range(nvars):
 % if c['ldg-beta'] == -0.5:
     urout[${i}] = ulin[${i}];

--- a/pyfr/solvers/navstokes/kernels/mpicflux.mako
+++ b/pyfr/solvers/navstokes/kernels/mpicflux.mako
@@ -8,13 +8,13 @@
 <% beta, tau = c['ldg-beta'], c['ldg-tau'] %>
 
 <%pyfr:kernel name='mpicflux' ndim='1'
-              ul='inout view fpdtype_t[${str(nvars)}]'
-              ur='inout mpi fpdtype_t[${str(nvars)}]'
-              gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              gradur='in mpi fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              ul='inout view fpdtype_t[${fmt(nvars)}]'
+              ur='inout mpi fpdtype_t[${fmt(nvars)}]'
+              gradul='in view fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              gradur='in mpi fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
               artviscl='in view fpdtype_t'
               artviscr='in mpi fpdtype_t'
-              nl='in fpdtype_t[${str(ndims)}]'>
+              nl='in fpdtype_t[${fmt(ndims)}]'>
     fpdtype_t mag_nl = sqrt(${pyfr.dot('nl[{i}]', i=ndims)});
     fpdtype_t norm_nl[] = ${pyfr.array('(1 / mag_nl)*nl[{i}]', i=ndims)};
 

--- a/pyfr/solvers/navstokes/kernels/mpiconu.mako
+++ b/pyfr/solvers/navstokes/kernels/mpiconu.mako
@@ -2,9 +2,9 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 <%pyfr:kernel name='mpiconu' ndim='1'
-              ulin='in view fpdtype_t[${str(nvars)}]'
-              urin='in mpi fpdtype_t[${str(nvars)}]'
-              ulout='out view fpdtype_t[${str(nvars)}]'>
+              ulin='in view fpdtype_t[${fmt(nvars)}]'
+              urin='in mpi fpdtype_t[${fmt(nvars)}]'
+              ulout='out view fpdtype_t[${fmt(nvars)}]'>
 % for i in range(nvars):
 % if c['ldg-beta'] == -0.5:
     ulout[${i}] = ulin[${i}];

--- a/pyfr/solvers/navstokes/kernels/tflux.mako
+++ b/pyfr/solvers/navstokes/kernels/tflux.mako
@@ -11,14 +11,14 @@
 <% rcpdjac = 'rcpdjac_l' if 'linear' in ktype else 'rcpdjac' %>
 
 <%pyfr:kernel name='tflux' ndim='2'
-              u='in fpdtype_t[${str(nvars)}]'
+              u='in fpdtype_t[${fmt(nvars)}]'
               artvisc='in broadcast-col fpdtype_t'
-              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              gradu='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
+              f='inout fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              gradu='inout fpdtype_t[${fmt(ndims)}][${fmt(nvars)}]'
+              smats='in fpdtype_t[${fmt(ndims)}][${fmt(ndims)}]'
               rcpdjac='in fpdtype_t'
-              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
-              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+              verts='in broadcast-col fpdtype_t[${fmt(nverts)}][${fmt(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${fmt(ndims)}]'>
 % if 'linear' in ktype:
     // Compute the S matrices
     fpdtype_t ${smats}[${ndims}][${ndims}], djac;


### PR DESCRIPTION
## Summary
- replace numeric str() formatting with fmt() in solver and integrator kernel templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b651e0cc8832fbe6072265ec2baf6