### PR TITLE
Add float formatter for kernel templates

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -92,6 +92,14 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
         # Macro definitions
         tplargs['_macros'] = {}
 
+        def fmt_float(x):
+            if isinstance(x, (float, np.floating)):
+                return np.format_float_positional(x, trim='-')
+            else:
+                return str(x)
+
+        tplargs['fmt'] = fmt_float
+
         # External kernel arguments dictionary
         tplargs['_extrns'] = extrns
 


### PR DESCRIPTION
## Summary
- Provide `fmt_float` helper for `_render_kernel` to output floats with full precision via `numpy.format_float_positional`
- Expose helper to kernel templates as `fmt` for consistent formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6d5ec3f0832fa10306394133f71b