### PR TITLE
Ensure tcurr stats use numeric config getter

### DIFF
--- a/pyfr/__main__.py
+++ b/pyfr/__main__.py
@@ -494,7 +494,7 @@ def process_resample(args):
         stats.set('data', 'prefix', prefix)
         stats.set('data', 'fields', ssoln['stats'].get('data', 'fields'))
         stats.set('solver-time-integrator', 'tcurr',
-                  ssoln['stats'].get('solver-time-integrator', 'tcurr'))
+                  ssoln['stats'].getfloat('solver-time-integrator', 'tcurr'))
         metadata = {'config': tcfg.tostr(), 'stats': stats.tostr(),
                     'mesh-uuid': treader.mesh.uuid}
     else:


### PR DESCRIPTION
## Summary
- use `getfloat` when copying `tcurr` to resampled stats to ensure numeric type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7f162c54832fa0998d1a0e3baac5