### PR TITLE
Ensure single precision literal suffixing

### DIFF
--- a/pyfr/backends/base/generator.py
+++ b/pyfr/backends/base/generator.py
@@ -233,7 +233,7 @@ class BaseKernelGenerator:
     def _render_body(self, body):
         # At single precision suffix all floating point constants by 'f'
         if self.fpdtype == np.float32:
-            body = re.sub(r'(?=\d*[.eE])(?=\.?\d)\d*\.?\d*(?:[eE][+-]?\d+)?',
+            body = re.sub(r'(?=\d*[.eE])(?=\.?\d)\d*\.?\d*(?:[eE][+-]?\d+)?(?![A-Za-z_])',
                           r'\g<0>f', body)
 
         # Dereference vector arguments
@@ -372,7 +372,10 @@ class BaseGPUKernelGenerator(BaseKernelGenerator):
         if preamble:
             preamble.append(f'{self._shared_sync};')
 
-        return self._render_body(body), '\n'.join(preamble)
+        rendered_body = self._render_body(body)
+        rendered_preamble = self._render_body('\n'.join(preamble)) if preamble else ''
+
+        return rendered_body, rendered_preamble
 
     def render(self):
         spec = self._render_spec()

--- a/pyfr/tests/test_render_kernel.py
+++ b/pyfr/tests/test_render_kernel.py
@@ -94,3 +94,27 @@ ${pyfr.expand('coeff', np.int32(2), np.float64(1/3))}
 
     assert 'idx = 2;' in src
     assert 'val = 0.3333333333333333;' in src
+
+
+def test_single_precision_literal_suffix():
+    generator_path = Path(__file__).resolve().parents[1] / 'backends' / 'base' / 'generator.py'
+    loader = imm.SourceFileLoader('generator_stub', str(generator_path))
+    spec = imu.spec_from_loader(loader.name, loader)
+    generator_mod = imu.module_from_spec(spec)
+    loader.exec_module(generator_mod)
+    BaseKernelGenerator = generator_mod.BaseKernelGenerator
+
+    g = BaseKernelGenerator('foo', 1, {}, 'fpdtype_t a = 1.0;', np.float32, np.int32)
+    assert '1.0f' in g.body
+
+
+def test_double_precision_literal_suffix():
+    generator_path = Path(__file__).resolve().parents[1] / 'backends' / 'base' / 'generator.py'
+    loader = imm.SourceFileLoader('generator_stub', str(generator_path))
+    spec = imu.spec_from_loader(loader.name, loader)
+    generator_mod = imu.module_from_spec(spec)
+    loader.exec_module(generator_mod)
+    BaseKernelGenerator = generator_mod.BaseKernelGenerator
+
+    g = BaseKernelGenerator('foo', 1, {}, 'fpdtype_t a = 1.0;', np.float64, np.int32)
+    assert '1.0f' not in g.body


### PR DESCRIPTION
## Summary
- avoid double suffixing of floating point constants and process preamble when targeting single precision
- test that kernel generator appends `f` for single precision literals and omits it for double

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b853f53a4832fa00efe3a294ff021