### PR TITLE
Guard numeric concatenation in templates

### DIFF
--- a/pyfr/backends/base/generator.py
+++ b/pyfr/backends/base/generator.py
@@ -135,7 +135,7 @@ class BaseKernelGenerator:
 
     def _match_arg(self, arg):
         bmtch = r'\[({0})\]'.format(match_paired_paren('[]'))
-        ptrns = [r'\b{0}\b', r'\b{0}' + bmtch, r'\b{0}' + 2*bmtch]
+        ptrns = [r'\b{0}\b', fr'\b{{0}}{bmtch}', fr'\b{{0}}{bmtch*2}']
 
         return ptrns[arg.ncdim].format(arg.name)
 
@@ -253,7 +253,7 @@ class BaseKernelGenerator:
                     body += f'{afun}(&{darg}, {va.name});\n'
                 else:
                     for ij in ndrange(*va.cdims):
-                        lval = va.name + ''.join(f'[{i}]' for i in ij)
+                        lval = f"{va.name}{''.join(f'[{i}]' for i in ij)}"
                         gval = re.sub(subp, darg, lval)
 
                         body += f'{afun}(&{gval}, {lval});\n'

--- a/pyfr/backends/metal/util.py
+++ b/pyfr/backends/metal/util.py
@@ -1,7 +1,8 @@
 def call_(obj, name_, **kwargs):
     keys = list(kwargs)
     keys[0] = keys[0][0].upper() + keys[0][1:]
-    meth = name_ + '_'.join(keys) + '_'
+    name_ = str(name_)
+    meth = f"{name_}{'_'.join(str(k) for k in keys)}_"
 
     return getattr(obj, meth)(*kwargs.values())
 

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -7,7 +7,7 @@ import re
 
 def _ensure_float(m):
     m = m[0]
-    return m if any(c in m for c in '.eE') else m + '.'
+    return m if any(c in m for c in '.eE') else f'{m}.'
 
 
 _sentinel = object()
@@ -79,7 +79,7 @@ class Inifile:
 
         # Substitute variables
         if subs:
-            expr = re.sub(r'\b({0})\b'.format('|'.join(subs)),
+            expr = re.sub(r'\b({0})\b'.format('|'.join(map(str, subs))),
                           lambda m: str(subs[m[1]]), expr)
 
         # Convert integers not inside [] to floats

--- a/pyfr/integrators/__init__.py
+++ b/pyfr/integrators/__init__.py
@@ -24,7 +24,7 @@ def get_integrator(backend, systemcls, mesh, initsoln, cfg):
         raise ValueError('Invalid integrator formulation')
 
     # Determine the integrator name
-    name = '_'.join([form, cn, sn, 'integrator'])
+    name = '_'.join(map(str, [form, cn, sn, 'integrator']))
     name = re.sub('(?:^|_|-)([a-z])', lambda m: m[1].upper(), name)
 
     # Composite the base classes together to form a new type

--- a/pyfr/integrators/dual/pseudo/__init__.py
+++ b/pyfr/integrators/dual/pseudo/__init__.py
@@ -36,7 +36,7 @@ def get_pseudo_integrator(backend, systemcls, mesh, initsoln, cfg, stepnregs,
         pc = get_pseudo_stepper_cls(pn, porder)
 
         # Determine the integrator name
-        name = '_'.join(['dual', cn, pn, 'pseudointegrator'])
+        name = '_'.join(map(str, ['dual', cn, pn, 'pseudointegrator']))
         name = re.sub('(?:^|_|-)([a-z])', lambda m: m[1].upper(), name)
 
         pseudointegrator = type(name, (cc, pc), dict(name=name))

--- a/pyfr/nputil.py
+++ b/pyfr/nputil.py
@@ -109,7 +109,7 @@ def npeval(expr, locals):
         raise ValueError('Invalid characters in expression')
 
     # Disallow access to object attributes
-    objs = '|'.join(it.chain(_npeval_syms, locals))
+    objs = '|'.join(map(str, it.chain(_npeval_syms, locals)))
     if re.search(rf'({objs}|\))\s*\.', expr):
         raise ValueError('Invalid expression')
 

--- a/pyfr/plugins/pseudostats.py
+++ b/pyfr/plugins/pseudostats.py
@@ -23,7 +23,7 @@ class PseudoStatsPlugin(BaseSolnPlugin):
 
         # The root rank needs to open the output file
         if rank == root:
-            header = 'n,t,i,' + fvars
+            header = f'n,t,i,{fvars}'
             self.csv = init_csv(self.cfg, cfgsect, header, nflush=500)
         else:
             self.csv = None

--- a/pyfr/progress.py
+++ b/pyfr/progress.py
@@ -223,10 +223,10 @@ class ProgressSequence:
     def start_with_sequence(self, phase):
         prefix, tstart = self._start_phase(phase)
 
-        sys.stderr.write(prefix + '\n')
+        sys.stderr.write(f'{prefix}\n')
         sys.stderr.flush()
 
-        yield ProgressSequence(prefix=self._prefix + '  ')
+        yield ProgressSequence(prefix=f'{self._prefix}  ')
 
     @contextlib.contextmanager
     def start_with_bar(self, phase):

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -214,7 +214,7 @@ class NativeReader:
             pname = einfo = ninfo = None
 
         # Broadcast this metadata
-        ppath = 'partitionings/' + comm.bcast(pname, root=root)
+        ppath = f'partitionings/{comm.bcast(pname, root=root)}'
         einfo = comm.scatter(einfo, root=root)
         self.neighbours = comm.scatter(ninfo, root=root)
 

--- a/pyfr/regions.py
+++ b/pyfr/regions.py
@@ -348,7 +348,7 @@ class ConstructiveRegion(BaseGeometricRegion):
         # Factor out the individual region expressions
         rexprs = []
         self.expr = re.sub(
-            r'(\w+)\((' + match_paired_paren('()') + r')\)',
+            rf'(\w+)\(({match_paired_paren("()")})\)',
             lambda m: rexprs.append(m.groups()) or f'r{len(rexprs) - 1}',
             expr
         )
@@ -367,7 +367,7 @@ class ConstructiveRegion(BaseGeometricRegion):
                 args = re.sub(fr'{k}\s*=\s*', f'(None, "{k}"), ', args)
 
             # Evaluate the arguments
-            argit = iter(literal_eval(args + ','))
+            argit = iter(literal_eval(f'{args},'))
 
             # Prepare the argument list
             kargs, kwargs = [], {'rdata': rdata}

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -149,7 +149,7 @@ class BaseAdvectionElements(BaseElements):
 
             # Allocate one minimum entropy value per interface
             self.nfaces = len(self.nfacefpts)
-            ext = nonce + 'entmin_int'
+            ext = f'{nonce}entmin_int'
 
             # Set values to -inf for pre-proc filter to enforce positivity
             entmin_int = np.full((self.nfaces, self.neles),

--- a/pyfr/solvers/baseadvecdiff/elements.py
+++ b/pyfr/solvers/baseadvecdiff/elements.py
@@ -138,7 +138,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
 
             # Allocate space for the artificial viscosity vector
             self.artvisc = self._be.matrix((1, self.neles),
-                                           extent=nonce + 'artvisc', tags=tags)
+                                           extent=f'{nonce}artvisc', tags=tags)
 
             # Apply the sensor to estimate the required artificial viscosity
             kernels['shocksensor'] = lambda uin: kernel(

--- a/pyfr/writers/csv.py
+++ b/pyfr/writers/csv.py
@@ -2,9 +2,10 @@
 
 class CSVStream:
     def __init__(self, fname, *, header=None, nflush=100):
-        # Append the '.csv' extension
+        # Ensure fname is a string and append the '.csv' extension
+        fname = str(fname)
         if not fname.endswith('.csv'):
-            fname += '.csv'
+            fname = f'{fname}.csv'
 
         # Open file for appending
         self.outf = open(fname, 'a')

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -43,9 +43,10 @@ class NativeWriter:
         self._ecounts = {etype: len(mesh.eidxs.get(etype, []))
                          for etype in mesh.etypes}
 
-        # Append the relevant extension
+        # Ensure basename is a string and append the relevant extension
+        basename = str(basename)
         if not basename.endswith(extn):
-            basename += extn
+            basename = f'{basename}{extn}'
 
         # Output counter (incremented each time write() is called)
         self.fgen = file_path_gen(basedir, basename, isrestart)


### PR DESCRIPTION
## Summary
- avoid mixing numeric values with strings in partition and output path builders
- sanitize template utilities and solvers to construct identifiers via f-strings
- ensure ini and evaluation helpers convert numeric tokens to strings before joining

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b974810a4832fa26fe35b2a5522ea