### PR TITLE
Suffix float constants for single precision kernels

### DIFF
--- a/pyfr/backends/openmp/generator.py
+++ b/pyfr/backends/openmp/generator.py
@@ -47,7 +47,7 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
                     }}
                 }}'''
 
-        return f'''
+        src = f'''
             struct {self.name}_kargs {{ {kargdefn}; }};
             void {self.name}(ixdtype_t _ib,
                              const struct {self.name}_kargs *args,
@@ -70,6 +70,8 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
                 #undef X_IDX_AOSOA
                 #undef BCAST_BLK
             }}'''
+
+        return self._postprocess_src(src)
 
     def ldim_size(self, name, factor=1):
         return f'{factor}*BLK_SZ' if factor > 1 else 'BLK_SZ'

--- a/pyfr/tests/test_render_kernel.py
+++ b/pyfr/tests/test_render_kernel.py
@@ -104,8 +104,12 @@ def test_single_precision_literal_suffix():
     loader.exec_module(generator_mod)
     BaseKernelGenerator = generator_mod.BaseKernelGenerator
 
-    g = BaseKernelGenerator('foo', 1, {}, 'fpdtype_t a = 1.0;', np.float32, np.int32)
-    assert '1.0f' in g.body
+    class DummyKernelGenerator(BaseKernelGenerator):
+        def render(self):
+            return self._postprocess_src(self.body)
+
+    g = DummyKernelGenerator('foo', 1, {}, 'fpdtype_t a = 1.0;', np.float32, np.int32)
+    assert '1.0f' in g.render()
 
 
 def test_double_precision_literal_suffix():
@@ -116,5 +120,9 @@ def test_double_precision_literal_suffix():
     loader.exec_module(generator_mod)
     BaseKernelGenerator = generator_mod.BaseKernelGenerator
 
-    g = BaseKernelGenerator('foo', 1, {}, 'fpdtype_t a = 1.0;', np.float64, np.int32)
-    assert '1.0f' not in g.body
+    class DummyKernelGenerator(BaseKernelGenerator):
+        def render(self):
+            return self._postprocess_src(self.body)
+
+    g = DummyKernelGenerator('foo', 1, {}, 'fpdtype_t a = 1.0;', np.float64, np.int32)
+    assert '1.0f' not in g.render()


### PR DESCRIPTION
## Summary
- Detect `np.float32` kernels and append `f` suffixes to floating-point literals
- Ensure OpenMP kernel generator applies the same post-processing
- Verify single vs. double precision literal handling in tests

## Testing
- `pytest pyfr/tests/test_render_kernel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b996ec33c832fb99488b50371341c